### PR TITLE
Support more events

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 ```
 
+You can also use this action with other events - you'll just need to specify a `tag_name` (see below).
+
 ## Options
 
 **setup**
@@ -53,7 +55,7 @@ The default is `npm ci && npm run build --if-present`. You can disable it entire
 
 **tag_name**
 
-The tag to update. If the workflow event is `release`, it will use the tag_name from the event payload. This option can be useful when using this action in a workflow with other actions that generate a release:
+The tag to update. If the workflow event is `release`, it will use the `tag_name` from the event payload. This option can be useful when using this action in a workflow with other actions that generate a release:
 
 ```yaml
 - uses: fictional/releaser@v1 # Not a real action!

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ You can customize the `setup` script that's run before pushing the files to the 
 
 The default is `npm ci && npm run build --if-present`. You can disable it entirely by setting `setup: ''`!
 
+**tag_name**
+
+The tag to update. If the workflow event is `release`, it will use the tag_name from the event payload. This option can be useful when using this action in a workflow with other actions that generate a release:
+
+```yaml
+- uses: fictional/releaser@v1 # Not a real action!
+  id: releaser
+- uses: JasonEtco/build-and-tag-action@v1
+  with:
+    tag_name: ${{ steps.releaser.outputs.tag_name }}
+```
+
 ## Motivation
 
 The [guide to JavaScript Actions](https://help.github.com/en/actions/building-actions/creating-a-javascript-action) recommends including `node_modules` in your repository, and manual steps to [following the versioning recommendations](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning). There are anti-patterns there that just don't sit right with me; so we can enable the same workflow, automatically!

--- a/action.yml
+++ b/action.yml
@@ -11,4 +11,4 @@ inputs:
     default: 'npm ci && npm run build --if-present'
     description: A command that runs before publishing the action to the release's tag.
   tag_name:
-    description: The tag to update. If the workflow event is `release`, it will use the tag_name from the event payload.
+    description: The tag to update. If the workflow event is `release`, it will use the `tag_name` from the event payload.

--- a/action.yml
+++ b/action.yml
@@ -10,3 +10,5 @@ inputs:
   setup:
     default: 'npm ci && npm run build --if-present'
     description: A command that runs before publishing the action to the release's tag.
+  tag_name:
+    description: The tag to update. If the workflow event is `release`, it will use the tag_name from the event payload.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,5 @@ import { Toolkit } from 'actions-toolkit'
 import buildAndTagAction from './lib'
 
 Toolkit.run(buildAndTagAction, {
-  event: 'release',
   secrets: ['GITHUB_TOKEN']
 })

--- a/src/lib/get-tag-name.ts
+++ b/src/lib/get-tag-name.ts
@@ -1,0 +1,13 @@
+import { Toolkit } from 'actions-toolkit'
+
+export default function getTagName(tools: Toolkit): string {
+  if (tools.inputs.tag_name) {
+    return tools.inputs.tag_name
+  }
+
+  if (tools.context.event === 'release') {
+    return tools.context.payload.release.tag_name
+  }
+
+  throw new Error('No tag_name was found or provided!')
+}

--- a/tests/get-tag-name.test.ts
+++ b/tests/get-tag-name.test.ts
@@ -1,0 +1,30 @@
+import getTagName from '../src/lib/get-tag-name'
+import { generateToolkit } from './helpers'
+import { Toolkit } from 'actions-toolkit'
+
+describe('update-tag', () => {
+  let tools: Toolkit
+
+  beforeEach(() => {
+    tools = generateToolkit()
+    delete process.env.INPUT_TAG_NAME
+  })
+
+  it('gets the tag from the release payload', () => {
+    const result = getTagName(tools)
+    expect(result).toBe('v1.0.0')
+  })
+
+  it('gets the tag from the release payload', () => {
+    process.env.INPUT_TAG_NAME = 'v2.1.1'
+    const result = getTagName(tools)
+    expect(result).toBe('v2.1.1')
+  })
+
+  it('gets the tag from the release payload', () => {
+    tools.context.event = 'pizza'
+    expect(() => getTagName(tools)).toThrowError(
+      'No tag_name was found or provided!'
+    )
+  })
+})


### PR DESCRIPTION
This PR removes the limitation around the trigger event being `release`. This was done to get the `tag_name` from the event payload - but we can set it as an `input` instead, and if the event is release and no `inputs.tag_name` was provided, we can still get it from there.

This should hopefully enable more re-use with different kinds of workflows! cc @bcoe :v: