### PR TITLE
Fix setup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@actions/exec": "^1.0.4",
+    "@actions/io": "^1.0.2",
     "actions-toolkit": "^4.0.0",
     "semver": "^7.3.2"
   },

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,6 @@
 import { Toolkit } from 'actions-toolkit'
 import { exec } from '@actions/exec'
+import { which } from '@actions/io'
 import createOrUpdateMajorRef from './create-or-update-major-ref'
 import createCommit from './create-commit'
 import updateTag from './update-tag'
@@ -9,7 +10,15 @@ export default async function buildAndTagAction(tools: Toolkit) {
   if (tools.inputs.setup) {
     // Run the setup script
     tools.log.info(`Running setup script: ${tools.inputs.setup}`)
-    await exec(tools.inputs.setup)
+
+    if (!which('bash')) {
+      // Ensure that bash is present
+      throw new Error(
+        "This environment does not have bash, so the setup script cannot be run. Set [with.setup: ''] to disable it."
+      )
+    }
+
+    await exec('bash -c', [tools.inputs.setup])
   } else {
     tools.log.info('Skipping setup script, none provided.')
   }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -122,7 +122,7 @@ describe('build-and-tag-action', () => {
 
     await buildAndTagAction(tools)
     expect(spy).toHaveBeenCalled()
-    expect(spy).toHaveBeenCalledWith('echo "Hello!"')
+    expect(spy).toHaveBeenCalledWith('bash -c', ['echo "Hello!"'])
   })
 
   it('updates the ref and creates a new major ref for an event other than `release`', async () => {


### PR DESCRIPTION
This fixes #4 by using `bash -c ${setup-script}`. By piping the output into bash, it supports the `&&` operator, which lets us use chained commands.