### PR TITLE
Add example `package.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ You can also use this action with other events - you'll just need to specify a `
 
 ## Example `package.json` for your project
 
-The two important thing you'll need to set in your action are the `main` field and the `build` script. Here's an example of a minimal `package.json` that will use `@vercel/ncc` to compile your action to `dist/index.js` and point `build-and-tag-action` at the compiled file:
+The two important thing you'll need to set in your action are the `main` field and the `build` script. Here's an example of a minimal `package.json` that will use `@vercel/ncc` to compile your action to `dist/index.js`, update your `action.yml` file to use the `node12` runtime and point `build-and-tag-action` at the compiled file:
 
 ```json
 {
   "name": "your-action-name",
   "main": "dist/index.js",
   "scripts": {
-    "build": "npx @vercel/ncc build"
+    "build": "npx @vercel/ncc build && npx convert-action"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ jobs:
 
 You can also use this action with other events - you'll just need to specify a `tag_name` (see below).
 
+## Example `package.json` for your project
+
+The two important thing you'll need to set in your action are the `main` field and the `build` script. Here's an example of a minimal `package.json` that will use `@vercel/ncc` to compile your action to `dist/index.js` and point `build-and-tag-action` at the compiled file:
+
+```json
+{
+  "name": "your-action-name",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "npx @vercel/ncc build"
+  }
+}
+```
+
+Your `package.json` will probably contain a `dependencies` section, in addition to other fields such as `license`.
+
 ## Options
 
 **setup**


### PR DESCRIPTION
It took me longer to figure out how to use this action than I'd have liked, so here's a docs PR! I believe the minimal `package.json` example will work for most people writing `node` actions.

One thing that caught me out is that any actions using `build-and-tag-action` currently won't work on their `main` branch as `using` in `action.yml` is set to `node12` but a compiled file does not exist in the repo.

`npx convert-action` rewrites the `runs` section in `action.yml`, allowing people to specify `using: docker` in their `action.yml` file on `main` (which enables people to use the bleeding edge if required) knowing that when `npm run build` is executed, `runs` will be changed to `node12`

For an example of this working, see the [actions run](https://github.com/mheap/github-action-required-labels/runs/1391135114?check_suite_focus=true) and [resulting tag commit](https://github.com/mheap/github-action-required-labels/commit/c1021ae643be7256d21caec582af08f09f71379e)