### PR TITLE
Add ability to include additional files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ The tag to update. If the workflow event is `release`, it will use the `tag_name
     tag_name: ${{ steps.releaser.outputs.tag_name }}
 ```
 
+**additional_files**
+
+If you need to include more than just `main` in your built commit, you can provide a list of comma separated files as the `additional_files` input. These files will be added and committed when the tag is updated:
+
+```yaml
+- uses: fictional/releaser@v1 # Not a real action!
+  id: releaser
+- uses: JasonEtco/build-and-tag-action@v1
+  with:
+    additional_files: 'index.cache.js,another.js'
+```
+
 ## Motivation
 
 The [guide to JavaScript Actions](https://help.github.com/en/actions/building-actions/creating-a-javascript-action) recommends including `node_modules` in your repository, and manual steps to [following the versioning recommendations](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning). There are anti-patterns there that just don't sit right with me; so we can enable the same workflow, automatically!

--- a/action.yml
+++ b/action.yml
@@ -9,3 +9,5 @@ branding:
 inputs:
   tag_name:
     description: The tag to update. If the workflow event is `release`, it will use the `tag_name` from the event payload.
+  additional_files:
+    description: Any additional files to include in the build

--- a/src/lib/create-commit.ts
+++ b/src/lib/create-commit.ts
@@ -1,6 +1,15 @@
 import { Toolkit } from 'actions-toolkit'
 import readFile from './read-file'
 
+// This isn't exported from @octokit/types
+declare type GitCreateTreeParamsTree = {
+  path?: string;
+  mode?: "100644" | "100755" | "040000" | "160000" | "120000";
+  type?: "blob" | "tree" | "commit";
+  sha?: string | null;
+  content?: string;
+}
+
 export default async function createCommit(tools: Toolkit) {
   const { main } = tools.getPackageJSON<{ main?: string }>()
 
@@ -9,22 +18,40 @@ export default async function createCommit(tools: Toolkit) {
   }
 
   tools.log.info('Creating tree')
+  let files: GitCreateTreeParamsTree[] = [
+    {
+      path: 'action.yml',
+      mode: '100644',
+      type: 'blob',
+      content: await readFile(tools.workspace, 'action.yml')
+    },
+    {
+      path: main,
+      mode: '100644',
+      type: 'blob',
+      content: await readFile(tools.workspace, main)
+    }
+  ];
+
+  // Add any additional files
+  if (tools.inputs.additional_files) {
+    const additional: GitCreateTreeParamsTree[] = await Promise.all(tools.inputs.additional_files.split(",")
+    .map(async path =>{
+      path = path.trim();
+      return {
+        path,
+        mode: '100644',
+        type: 'blob',
+        content: await readFile(tools.workspace, path)
+      } as GitCreateTreeParamsTree;
+    }));
+
+    files = files.concat(additional);
+  }
+
   const tree = await tools.github.git.createTree({
     ...tools.context.repo,
-    tree: [
-      {
-        path: 'action.yml',
-        mode: '100644',
-        type: 'blob',
-        content: await readFile(tools.workspace, 'action.yml')
-      },
-      {
-        path: main,
-        mode: '100644',
-        type: 'blob',
-        content: await readFile(tools.workspace, main)
-      }
-    ]
+    tree: files
   })
 
   tools.log.complete('Tree created')

--- a/tests/create-commit.test.ts
+++ b/tests/create-commit.test.ts
@@ -37,6 +37,28 @@ describe('create-commit', () => {
     expect(commitParams.parents).toEqual([tools.context.sha])
   })
 
+  it('creates the tree and commit with additional files', async () => {
+    process.env.INPUT_ADDITIONAL_FILES="package.json,additional.js"
+
+    await createCommit(tools)
+    expect(nock.isDone()).toBe(true)
+
+    // Test that our tree was created correctly
+    expect(treeParams.tree).toHaveLength(4)
+    expect(treeParams.tree.some((obj: any) => obj.path === 'package.json')).toBe(
+      true
+    )
+    expect(treeParams.tree.some((obj: any) => obj.path === 'additional.js')).toBe(
+      true
+    )
+
+    // Test that our commit was created correctly
+    expect(commitParams.message).toBe('Automatic compilation')
+    expect(commitParams.parents).toEqual([tools.context.sha])
+
+    delete process.env.INPUT_ADDITIONAL_FILES;
+  })
+
   it('creates the tree and commit', async () => {
     jest.spyOn(tools, 'getPackageJSON').mockReturnValueOnce({})
     await expect(() => createCommit(tools)).rejects.toThrow(


### PR DESCRIPTION
Include files other than `main` when creating a commit to update a tag. This will not be needed by most people, but is required if you're bundling `ncc` using `ncc` due to `Error: ENOENT: no such file or directory, open '/home/runner/work/_actions/owner/repo/v1/dist/index.js.cache.js'`