### PR TITLE
allow specifying commit message from action input

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ The tag to update. If the workflow event is `release`, it will use the `tag_name
     tag_name: ${{ steps.releaser.outputs.tag_name }}
 ```
 
+**commit_message**
+
+Commit message.
+
+```yaml
+- uses: fictional/releaser@v1 # Not a real action!
+  id: releaser
+- uses: JasonEtco/build-and-tag-action@v2
+  with:
+    commit_message: Built with love!
+```
+
 ## Motivation
 
 The [guide to JavaScript Actions](https://help.github.com/en/actions/building-actions/creating-a-javascript-action) recommends including `node_modules` in your repository, and manual steps to [following the versioning recommendations](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning). There are anti-patterns there that just don't sit right with me; so we can enable the same workflow, automatically!

--- a/action.yml
+++ b/action.yml
@@ -9,3 +9,5 @@ branding:
 inputs:
   tag_name:
     description: The tag to update. If the workflow event is `release`, it will use the `tag_name` from the event payload.
+  commit_message:
+    description: Commit message.

--- a/src/lib/create-commit.ts
+++ b/src/lib/create-commit.ts
@@ -1,7 +1,7 @@
 import { Toolkit } from 'actions-toolkit'
 import readFile from './read-file'
 
-export default async function createCommit(tools: Toolkit) {
+export default async function createCommit(tools: Toolkit, commitMessage?: string) {
   const { main } = tools.getPackageJSON<{ main?: string }>()
 
   if (!main) {
@@ -32,7 +32,7 @@ export default async function createCommit(tools: Toolkit) {
   tools.log.info('Creating commit')
   const commit = await tools.github.git.createCommit({
     ...tools.context.repo,
-    message: 'Automatic compilation',
+    message: commitMessage || 'Automatic compilation',
     tree: tree.data.sha,
     parents: [tools.context.sha]
   })

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -10,8 +10,11 @@ export default async function buildAndTagAction(tools: Toolkit) {
   const tagName = getTagName(tools)
   tools.log.info(`Updating tag [${tagName}]`)
 
+  // get commit message from input (if any)
+  const commitMessage = tools.inputs.commit_message
+
   // Create a new commit, with the new tree
-  const commit = await createCommit(tools)
+  const commit = await createCommit(tools, commitMessage)
 
   // Update the tag to point to the new commit
   await updateTag(tools, commit.sha, tagName)

--- a/tests/create-commit.test.ts
+++ b/tests/create-commit.test.ts
@@ -37,6 +37,24 @@ describe('create-commit', () => {
     expect(commitParams.parents).toEqual([tools.context.sha])
   })
 
+  it('creates the tree and commit with commit message', async () => {
+    const msg = "TEST COMMIT MESSAGE"
+
+    await createCommit(tools, msg)
+    expect(nock.isDone()).toBe(true)
+
+    // Test that our tree was created correctly
+    expect(treeParams.tree).toHaveLength(2)
+    expect(treeParams.tree.some((obj: any) => obj.path === 'index.js')).toBe(
+      true
+    )
+
+    // Test that our commit was created correctly
+    expect(commitParams.message).toBe(msg)
+    expect(commitParams.parents).toEqual([tools.context.sha])
+  })
+
+
   it('creates the tree and commit', async () => {
     jest.spyOn(tools, 'getPackageJSON').mockReturnValueOnce({})
     await expect(() => createCommit(tools)).rejects.toThrow(


### PR DESCRIPTION
Adding `commit_message` input to allow specifying commit message.