### PR TITLE
add commit_sha output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,3 +9,6 @@ branding:
 inputs:
   tag_name:
     description: The tag to update. If the workflow event is `release`, it will use the `tag_name` from the event payload.
+outputs:
+  commit_sha:
+    description: SHA of the commit newly created.

--- a/src/lib/create-commit.ts
+++ b/src/lib/create-commit.ts
@@ -36,7 +36,7 @@ export default async function createCommit(tools: Toolkit) {
     tree: tree.data.sha,
     parents: [tools.context.sha]
   })
-  tools.log.complete('Commit created')
+  tools.log.complete(`Commit created (${commit.data.sha})`)
 
   return commit.data
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -13,6 +13,9 @@ export default async function buildAndTagAction(tools: Toolkit) {
   // Create a new commit, with the new tree
   const commit = await createCommit(tools)
 
+  // set the new commit's sha as an output
+  tools.outputs.commit_sha = commit.sha
+
   // Update the tag to point to the new commit
   await updateTag(tools, commit.sha, tagName)
 


### PR DESCRIPTION
Add `commit_sha` as an action output for use in subsequent steps.