### PR TITLE
docs: update Node.js runtime version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can also use this action with other events - you'll just need to specify a `
 
 ## Example `package.json` for your project
 
-The two important thing you'll need to set in your action are the `main` field and the `build` script. Here's an example of a minimal `package.json` that will use `@vercel/ncc` to compile your action to `dist/index.js`, update your `action.yml` file to use the `node12` runtime and point `build-and-tag-action` at the compiled file:
+The two important thing you'll need to set in your action are the `main` field and the `build` script. Here's an example of a minimal `package.json` that will use `@vercel/ncc` to compile your action to `dist/index.js`, update your `action.yml` file to use the `node16` runtime and point `build-and-tag-action` at the compiled file:
 
 ```json
 {


### PR DESCRIPTION
convert-action has been [updated to the node16 runtime](https://github.com/mheap/convert-action/pull/3).