### PR TITLE
Upgrade to node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 16.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
       - run: npm ci
       - run: npm test
       - name: codecov

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Build and Tag
 description: Properly tags your GitHub Action
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: archive


### PR DESCRIPTION
This PR upgrades the action to use Node 20 as its execution environment.
As Node 16 has been deprecated, we need this upgrade to stop the deprecation message from showing when using this action:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: JasonEtco/build-and-tag-action@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
```

Closes #48